### PR TITLE
Add pointer-events css property to the popup anchor.

### DIFF
--- a/resources/css/popup.css
+++ b/resources/css/popup.css
@@ -5,6 +5,7 @@
     z-index: 2;
     height: 16px;
     width: 31px;
+    pointer-events: none;
 }
 
 .gx-popup-anc.top {


### PR DESCRIPTION
By adding `pointer-events: none;` to the `.gx-popup-anc` class, the click events are not stopped by the div.

Tested on Chrome and FF. 
