### PR TITLE
noImgCls to control the LegendImage style

### DIFF
--- a/lib/GeoExt/widgets/LegendImage.js
+++ b/lib/GeoExt/widgets/LegendImage.js
@@ -38,6 +38,12 @@ GeoExt.LegendImage = Ext.extend(Ext.BoxComponent, {
      */
     imgCls: null,
     
+    /** private: config[noImgCls]
+     *  ``String`` CSS class applied to img tag when no image is available or
+     *  the default image was loaded.
+     */
+    noImgCls: "gx-legend-noimage",
+    
     /** private: method[initComponent]
      *  Initializes the legend image component. 
      */
@@ -48,7 +54,7 @@ GeoExt.LegendImage = Ext.extend(Ext.BoxComponent, {
         }
         this.autoEl = {
             tag: "img",
-            "class": (this.imgCls ? this.imgCls : ""),
+            "class": (this.imgCls ? this.imgCls + " " + this.noImgCls : this.noImgCls),
             src: this.defaultImgSrc
         };
     },
@@ -62,6 +68,8 @@ GeoExt.LegendImage = Ext.extend(Ext.BoxComponent, {
         this.url = url;
         var el = this.getEl();
         if (el) {
+            el.un("load", this.onImageLoad, this);
+            el.on("load", this.onImageLoad, this, {single: true});
             el.un("error", this.onImageLoadError, this);
             el.on("error", this.onImageLoadError, this, {single: true});
             el.dom.src = url;
@@ -85,6 +93,7 @@ GeoExt.LegendImage = Ext.extend(Ext.BoxComponent, {
     onDestroy: function() {
         var el = this.getEl();
         if(el) {
+            el.un("load", this.onImageLoad, this);
             el.un("error", this.onImageLoadError, this);
         }
         GeoExt.LegendImage.superclass.onDestroy.apply(this, arguments);
@@ -94,7 +103,19 @@ GeoExt.LegendImage = Ext.extend(Ext.BoxComponent, {
      *  Private method called if the legend image fails loading.
      */
     onImageLoadError: function() {
-        this.getEl().dom.src = this.defaultImgSrc;
+        var el = this.getEl();
+        el.addClass(this.noImgCls);
+        el.dom.src = this.defaultImgSrc;
+    },
+    
+    /** private: method[onImageLoad]
+     *  Private method called after the legend image finished loading.
+     */
+    onImageLoad: function() {
+        var el = this.getEl();
+        if (!OpenLayers.Util.isEquivalentUrl(el.dom.src, this.defaultImgSrc)) {
+            el.removeClass(this.noImgCls);
+        }
     }
 
 });

--- a/tests/lib/GeoExt/widgets/LegendImage.html
+++ b/tests/lib/GeoExt/widgets/LegendImage.html
@@ -26,7 +26,7 @@
         }
         
         function test_onImageLoadError(t) {
-            t.plan(2);
+            t.plan(3);
             
             var legend, calls = 0;
 
@@ -44,9 +44,31 @@
                 t.eq(calls, 1, "onImageLoadError called once for bogus image src");
                 var el = legend.getEl();
                 t.eq(el && el.dom.src.split("/").pop(), "also-bogus", "defaultImgSrc set as image src");
+                t.ok(el.dom.className.indexOf(legend.noImgCls) !== -1, "noImgCls set");
                 legend.destroy();
             });            
             
+        }
+        
+        function test_onImageLoad(t) {
+            t.plan(2);
+            
+            var calls = 0;
+            var legend = new GeoExt.LegendImage({
+                url: Ext.BLANK_IMAGE_URL,
+                defaultImgSrc: "bogus",
+                renderTo: "legend",
+                onImageLoad: function() {
+                    ++calls;
+                    GeoExt.LegendImage.prototype.onImageLoad.apply(this, arguments);
+                }
+            });
+            t.delay_call(1, function() {
+                t.eq(calls, 1, "onImageLoad called once for valid image src");
+                var el = legend.getEl();
+                t.ok(el.dom.className.indexOf(legend.noImgCls) === -1, "noImgCls not set");
+                legend.destroy();
+            });            
         }
 
 


### PR DESCRIPTION
This change adds a "gx-legend-noimage" class to the img tag of a legend image if the requested image is not yet loaded or could not be loaded.
