### PR TITLE
Fixing legend url with custom format.

### DIFF
--- a/lib/GeoExt/widgets/WMSLegend.js
+++ b/lib/GeoExt/widgets/WMSLegend.js
@@ -144,9 +144,15 @@ GeoExt.WMSLegend = Ext.extend(GeoExt.LayerLegend, {
                 TIME: null
             });
         }
+        var params = Ext.apply({}, this.baseParams);
+        if (layer.params._OLSALT) {
+            // update legend after a forced layer redraw
+            params._OLSALT = layer.params._OLSALT;
+        }
+        url = Ext.urlAppend(url, Ext.urlEncode(params));
         if (url.toLowerCase().indexOf("request=getlegendgraphic") != -1) {
             if (url.toLowerCase().indexOf("format=") == -1) {
-                url = Ext.urlAppend(url, "FORMAT=image/gif");
+                url = Ext.urlAppend(url, "FORMAT=image%2Fgif");
             }
             // add scale parameter - also if we have the url from the record's
             // styles data field and it is actually a GetLegendGraphic request.
@@ -155,12 +161,6 @@ GeoExt.WMSLegend = Ext.extend(GeoExt.LayerLegend, {
                 url = Ext.urlAppend(url, "SCALE=" + scale);
             }
         }
-        var params = Ext.apply({}, this.baseParams);
-        if (layer.params._OLSALT) {
-            // update legend after a forced layer redraw
-            params._OLSALT = layer.params._OLSALT;
-        }
-        url = Ext.urlAppend(url, Ext.urlEncode(params));
         
         return url;
     },

--- a/tests/lib/GeoExt/widgets/WMSLegend.html
+++ b/tests/lib/GeoExt/widgets/WMSLegend.html
@@ -43,8 +43,8 @@
 
             t.eq(l.items.length, 5, "We expect 5 items");
             url = l.items.get(1).url;
-            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&SCALE=27683990.15625&FORMAT=image%2Fgif";
-            t.ok(OpenLayers.Util.isEquivalentUrl(url, expectedUrl), "GetLegendGraphic url is generated correctly");
+            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&FORMAT=image%2Fgif&SCALE=27683990.15625";
+            t.eq(url, expectedUrl, "GetLegendGraphic url is generated correctly");
             l.destroy();
 
             l = new GeoExt.WMSLegend({
@@ -55,8 +55,8 @@
 
             t.eq(l.items.length, 3, "We expect 3 items");
             url = l.items.get(1).url;
-            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=x&SCALE=27683990.15625&FORMAT=image%2Fgif";
-            t.ok(OpenLayers.Util.isEquivalentUrl(url, expectedUrl), "GetLegendGraphic url is generated correctly");
+            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=x&FORMAT=image%2Fgif&SCALE=27683990.15625";
+            t.eq(url, expectedUrl, "GetLegendGraphic url is generated correctly");
             l.destroy();
         }
 
@@ -77,7 +77,7 @@
             url = l.items.get(1) && l.items.get(1).url;
             t.eq(!!url, true, "legend image loaded even when MapPanel is not rendered at legend instantiation.")
             expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&FORMAT=image%2Fpng&foo=bar%20bar";
-            t.ok(OpenLayers.Util.isEquivalentUrl(url, expectedUrl), "GetLegendGraphic url is generated correctly");
+            t.eq(url, expectedUrl, "GetLegendGraphic url is generated correctly");
             l.destroy()
 
             l = new GeoExt.WMSLegend({
@@ -89,7 +89,7 @@
 
             url = l.items.get(1).url;
             expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&FORMAT=image%2Fgif";
-            t.ok(OpenLayers.Util.isEquivalentUrl(url, expectedUrl), "GetLegendGraphic url is generated correctly");
+            t.eq(url, expectedUrl, "GetLegendGraphic url is generated correctly");
             l.destroy()
 
             l = new GeoExt.WMSLegend({
@@ -99,8 +99,8 @@
             l.render();
 
             url = l.items.get(1).url;
-            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&SCALE=27683990.15625&FORMAT=image%2Fgif";
-            t.ok(OpenLayers.Util.isEquivalentUrl(url, expectedUrl), "GetLegendGraphic url is generated correctly");
+            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&FORMAT=image%2Fgif&SCALE=27683990.15625";
+            t.eq(url, expectedUrl, "GetLegendGraphic url is generated correctly");
             l.destroy();
             
             mapPanel.map.layers[0].params.STYLES = "bar";
@@ -128,7 +128,7 @@
             });
             l.render();
             url = l.items.get(1).url;
-            t.eq(url, "foo?request=getlegendgraphic&FORMAT=image/gif&SCALE=" + mapPanel.map.getScale(), "legend url from styles field with default format.");
+            t.eq(url, "foo?request=getlegendgraphic&FORMAT=image%2Fgif&SCALE=" + mapPanel.map.getScale(), "legend url from styles field with default format.");
             l.destroy();
 
             mapPanel.layers.getAt(0).set("styles", [{
@@ -164,8 +164,8 @@
             });
             l.render();
             url = l.items.get(1).url;
-            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&SLD=sld&LAYER=a&SCALE=27683990.15625&FORMAT=image%2Fgif";
-            t.ok(OpenLayers.Util.isEquivalentUrl(url, expectedUrl), "GetLegendGraphic url is generated when layer has SLD set");
+            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&SLD=sld&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&FORMAT=image%2Fgif&SCALE=27683990.15625";
+            t.eq(url, expectedUrl, "GetLegendGraphic url is generated when layer has SLD set");
             l.destroy();
             delete mapPanel.map.layers[0].params.SLD;
 
@@ -177,13 +177,13 @@
             });
             l.render();
             url = l.items.get(1).url;
-            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&SLD_BODY=sld_body&LAYER=a&SCALE=27683990.15625&FORMAT=image%2Fgif";
-            t.ok(OpenLayers.Util.isEquivalentUrl(url, expectedUrl), "GetLegendGraphic url is generated when layer has SLD_BODY set");
+            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&SLD_BODY=sld_body&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&FORMAT=image%2Fgif&SCALE=27683990.15625";
+            t.eq(url, expectedUrl, "GetLegendGraphic url is generated when layer has SLD_BODY set");
 
             mapPanel.map.zoomIn();
             url = l.items.get(1).url;
-            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&SLD_BODY=sld_body&LAYER=a&SCALE=13841995.078125&FORMAT=image%2Fgif";
-            t.ok(OpenLayers.Util.isEquivalentUrl(url, expectedUrl), "GetLegendGraphic url changes when map scale changes");
+            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&SLD_BODY=sld_body&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&FORMAT=image%2Fgif&SCALE=13841995.078125";
+            t.eq(url, expectedUrl, "GetLegendGraphic url changes when map scale changes");
 
             l.destroy();
             delete mapPanel.map.layers[0].params.SLD_BODY;
@@ -226,11 +226,11 @@
             l.update();
             t.ok(l.getComponent("b"),
                  "update does not remove components to be updated");
-            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&FOO=bar&LAYER=b&SCALE=27683990.15625&FORMAT=image%2Fgif";
-            t.ok(OpenLayers.Util.isEquivalentUrl(l.getComponent("b").url, expectedUrl),
+            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&FOO=bar&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=b&FORMAT=image%2Fgif&SCALE=27683990.15625";
+            t.eq(l.getComponent("b").url, expectedUrl,
                  "update updates component URL");
-            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&FOO=bar&LAYER=c&SCALE=27683990.15625&FORMAT=image%2Fgif";
-            t.ok(OpenLayers.Util.isEquivalentUrl(l.getComponent("c").url, expectedUrl),
+            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&FOO=bar&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=c&FORMAT=image%2Fgif&SCALE=27683990.15625";
+            t.eq(l.getComponent("c").url, expectedUrl,
                  "update sets correct URL in new component");
 
             // #3
@@ -238,9 +238,9 @@
                 layers: "c",
                 styles: "style1"
             });
-            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&FOO=bar&LAYER=c&STYLE=style1&SCALE=27683990.15625&FORMAT=image%2Fgif";
+            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&FOO=bar&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=c&STYLE=style1&FORMAT=image%2Fgif&SCALE=27683990.15625";
             l.update();
-            t.ok(OpenLayers.Util.isEquivalentUrl(l.getComponent("c").url, expectedUrl),
+            t.eq(l.getComponent("c").url, expectedUrl,
                  "update sets correct STYLE params in URL");
 
             // #4
@@ -252,7 +252,7 @@
             }]);
             l.update();
             expectedUrl = "http://url-to-legend.org/";
-            t.ok(OpenLayers.Util.isEquivalentUrl(l.getComponent("c").url, expectedUrl),
+            t.eq(l.getComponent("c").url, expectedUrl,
                  "update uses the legend href from the styles field");
 
             // #5
@@ -262,8 +262,8 @@
                 sld: "http://url-to-sld.org/"
             });
             l.update();
-            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&FOO=bar&SLD=http%3A%2F%2Furl-to-sld.org%2F&LAYER=c&SCALE=27683990.15625&FORMAT=image%2Fgif";
-            t.ok(OpenLayers.Util.isEquivalentUrl(l.getComponent("c").url, expectedUrl),
+            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&FOO=bar&SLD=http%3A%2F%2Furl-to-sld.org%2F&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=c&FORMAT=image%2Fgif&SCALE=27683990.15625";
+            t.eq(l.getComponent("c").url, expectedUrl,
                  "update does not use the legend href from the " +
                  "styles field if SLD is set in the layer params");
 
@@ -276,7 +276,7 @@
             l.update();
             var oldUrl = l.getComponent("c").url
             layerRecord.getLayer().redraw(true);
-            t.ok(OpenLayers.Util.isEquivalentUrl(l.getComponent("c").url, oldUrl + "&_OLSALT=" + layerRecord.getLayer().params._OLSALT),
+            t.eq(l.getComponent("c").url, oldUrl + "&_OLSALT=" + layerRecord.getLayer().params._OLSALT,
                  "update adds random parameter to disable caching after forced redraw");
             layerRecord.set("styles", null);
 
@@ -288,8 +288,8 @@
                 time: "2004-10-12T13:55:20Z"
             });
             l.update();
-            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&FOO=bar&LAYER=c&SCALE=27683990.15625&FORMAT=image%2Fgif";
-            t.ok(OpenLayers.Util.isEquivalentUrl(l.getComponent("c").url, expectedUrl),
+            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&FOO=bar&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=c&FORMAT=image%2Fgif&SCALE=27683990.15625";
+            t.eq(l.getComponent("c").url, expectedUrl,
                  "update updates component URL but ignored TIME parameter");
 
             // tear down


### PR DESCRIPTION
The tests didn't show the issue because of the use of OpenLayers.Util.isEquivalentUrl, but the way the addition of the default image/gif format is implemented, it will be appended to a format that was defined in baseParams. To avoid this, we append to the url after baseParams were appended.
