### PR TITLE
Add transformFeatureOptions option to GeoExt.plugins.PrintExtent.

### DIFF
--- a/lib/GeoExt/plugins/PrintExtent.js
+++ b/lib/GeoExt/plugins/PrintExtent.js
@@ -87,6 +87,12 @@ GeoExt.plugins.PrintExtent = Ext.extend(Ext.util.Observable, {
      */
     layer: null,
     
+    /** api: config[transformFeatureOptions]
+     *  ``Object`` Optional options for the`OpenLayers.Control.TransformFeature` 
+     *  control.
+     */
+    transformFeatureOptions: null,
+
     /** private: property[control]
      *  ``OpenLayers.Control.TransformFeature`` The control used to change
      *      extent, center, rotation and scale.
@@ -310,7 +316,7 @@ GeoExt.plugins.PrintExtent = Ext.extend(Ext.util.Observable, {
     /** private: method[createControl]
      */
     createControl: function() {
-        this.control = new OpenLayers.Control.TransformFeature(this.layer, {
+        this.control = new OpenLayers.Control.TransformFeature(this.layer, Ext.applyIf({
             preserveAspectRatio: true,
             eventListeners: {
                 "beforesetfeature": function(e) {
@@ -364,7 +370,7 @@ GeoExt.plugins.PrintExtent = Ext.extend(Ext.util.Observable, {
                 "transformcomplete": this.updateBox,
                 scope: this
             }
-        });
+        }, this.transformFeatureOptions));
     },
 
     /** private: method[fitPage]

--- a/tests/lib/GeoExt/plugins/PrintExtent.html
+++ b/tests/lib/GeoExt/plugins/PrintExtent.html
@@ -52,6 +52,38 @@
             mapPanel.destroy();
          }
 
+         function test_transformFeatureOptions(t) {
+             t.plan(2);
+
+             var printExtent = new GeoExt.plugins.PrintExtent({
+                 transformFeatureOptions: {
+                     rotate: false,
+                     renderIntent: "foobar"
+                 },
+                 printProvider: new GeoExt.data.PrintProvider({
+                     capabilities: printCapabilities
+                 })
+             });
+
+             var mapPanel = new GeoExt.MapPanel({
+                 renderTo: "mappanel",
+                 width: 256,
+                 height: 256,
+                 map: {controls: []},
+                 layers: [new OpenLayers.Layer("layer", {isBaseLayer: true})],
+                 center: [146.56, -41.56],
+                 zoom: 7,
+                 plugins: [printExtent]
+             });
+
+             t.ok(printExtent.control.rotate === false,
+                  "transformFeatureOptions.rotate option passed to the control");
+             t.ok(printExtent.control.renderIntent === "foobar",
+                  "transformFeatureOptions.renderIntent option passed to the control");
+
+             mapPanel.destroy();
+        }
+
         function test_destroy(t) {
             t.plan(3);
 


### PR DESCRIPTION
Optional config Object to be passed to the `OpenLayers.Control.TransformFeature` constructor.
