### PR TITLE
Append MapPanel items to the map's viewport div.

### DIFF
--- a/lib/GeoExt/widgets/MapPanel.js
+++ b/lib/GeoExt/widgets/MapPanel.js
@@ -196,12 +196,14 @@ GeoExt.MapPanel = Ext.extend(Ext.Panel, {
         });
         //TODO This should be handled by a LayoutManager
         this.on("afterlayout", function() {
-            var mapViewPort = Ext.query(".olMapViewport", this.map.div)[0];
-            this.items.each(function(cmp) {
-                if (typeof cmp.addToMapPanel === "function") {
-                    cmp.getEl().appendTo(mapViewPort);
-                }
-            }, this);
+            //TODO remove function check when we require OpenLayers > 2.11
+            if (typeof this.map.getViewport === "function") {
+                this.items.each(function(cmp) {
+                    if (typeof cmp.addToMapPanel === "function") {
+                        cmp.getEl().appendTo(this.map.getViewport());
+                    }
+                }, this);
+            }
         }, this);
     },
 

--- a/tests/lib/GeoExt/widgets/MapPanel.html
+++ b/tests/lib/GeoExt/widgets/MapPanel.html
@@ -658,7 +658,8 @@
                     ref: "zoomSlider"
                 }
             });
-            t.ok(mapPanel.zoomSlider.getEl().dom.parentNode === Ext.query(".olMapViewport", mapPanel.map.div)[0], "MapPanel item has the map's viewport div as parent.");
+            var mapdiv = typeof mapPanel.map.getViewport === "function" ? mapPanel.map.getViewport() : mapPanel.map.div;
+            t.ok(mapPanel.zoomSlider.getEl().dom.parentNode === mapdiv, "MapPanel item has the correct div as parent.");
             mapPanel.destroy();
         }
     </script>


### PR DESCRIPTION
After https://github.com/openlayers/openlayers/pull/164, the drag handler no longer interfers with controls on top of the map. With this change, it also does not interfer with MapPanel items, and we get back the behavior we used to have with OpenLayers 2.10.
