### PR TITLE
Vector layer issues with PrintMapPanel

### DIFF
--- a/lib/GeoExt/widgets/PrintMapPanel.js
+++ b/lib/GeoExt/widgets/PrintMapPanel.js
@@ -193,7 +193,20 @@ GeoExt.PrintMapPanel = Ext.extend(GeoExt.MapPanel, {
         this.layers = [];
         var layer;
         Ext.each(this.sourceMap.layers, function(layer) {
-            layer.getVisibility() === true && this.layers.push(layer.clone());
+            if (layer.getVisibility() === true) {
+                if (layer instanceof OpenLayers.Layer.Vector) {
+                    var features = layer.features,
+                        clonedFeatures = new Array(features.length),
+                        vector = new OpenLayers.Layer.Vector(layer.name);
+                    for (var i=0, ii=features.length; i<ii; ++i) {
+                        clonedFeatures[i] = features[i].clone();
+                    }
+                    vector.addFeatures(clonedFeatures, {silent: true});
+                    this.layers.push(vector);
+                } else {
+                    this.layers.push(layer.clone());
+                }
+            }
         }, this);
 
         this.extent = this.sourceMap.getExtent();


### PR DESCRIPTION
This is basically a patch made by Andreas sent on the users mailing list on January 14th 2012, but with some minor modifications.

The issue is originally caused by : 
  http://trac.osgeo.org/openlayers/ticket/2749

So, a way to work around this is to avoid cloning OpenLayers.Layer.Vector object.  Instead, creating a new instance and pushing cloned features does the trick.
