### PR TITLE
advertize GeoExt.LayerStore bind/unbind as api methods

### DIFF
--- a/lib/GeoExt/data/LayerStore.js
+++ b/lib/GeoExt/data/LayerStore.js
@@ -124,7 +124,7 @@ GeoExt.data.LayerStoreMixin = function() {
             }
         },
 
-        /** private: method[bind]
+        /** api: method[bind]
          *  :param map: ``OpenLayers.Map`` The map instance.
          *  :param options: ``Object``
          *  
@@ -178,7 +178,7 @@ GeoExt.data.LayerStoreMixin = function() {
             this.fireEvent("bind", this, map);
         },
 
-        /** private: method[unbind]
+        /** api: method[unbind]
          *  Unbind this store from the map it is currently bound.
          */
         unbind: function() {


### PR DESCRIPTION
actually it can be useful to bind the LayerStore to a map on demand, when the LayerStore have already been created.
