### PR TITLE
Hide combobox trigger on geocoder examples

### DIFF
--- a/examples/geocoder-geonames.js
+++ b/examples/geocoder-geonames.js
@@ -23,6 +23,7 @@ Ext.onReady(function() {
         zoom: 1,
         tbar: [{
             xtype: "gx_geocodercombo",
+            hideTrigger: true,
             emptyText: "Search GeoNames",
             width: 300,
             tpl: '<tpl for="."><div class="x-combo-list-item">[{countryName}] {name}</div></tpl>',

--- a/examples/geocoder-google.js
+++ b/examples/geocoder-google.js
@@ -35,6 +35,7 @@ Ext.onReady(function() {
         zoom: 1,
         tbar: [{
             xtype: "gx_geocodercombo",
+            hideTrigger: true,
             width: 250,
             layer: locationLayer,
             displayField: "formatted_address",

--- a/examples/geocoder-wfs.js
+++ b/examples/geocoder-wfs.js
@@ -26,6 +26,7 @@ Ext.onReady(function() {
         zoom: 3,
         tbar: [{
             xtype: "gx_geocodercombo",
+            hideTrigger: true,
             srs: "EPSG:900913",
             emptyText: 'Search for a US state',
             queryParam: "CQL_FILTER",

--- a/examples/geocoder.js
+++ b/examples/geocoder.js
@@ -31,6 +31,7 @@ Ext.onReady(function() {
         zoom: 1,
         tbar: [{
             xtype: "gx_geocodercombo",
+            hideTrigger: true,
             layer: locationLayer,
             // To restrict the search to a bounding box, uncomment the following
             // line and change the viewboxlbrt parameter to a left,bottom,right,top


### PR DESCRIPTION
The dropdown arrow is confusing and doesn't do anything functional.
