### PR TITLE
when displaying labels in the FeatureRenderer, make sure that we actuall...

### DIFF
--- a/lib/GeoExt/widgets/FeatureRenderer.js
+++ b/lib/GeoExt/widgets/FeatureRenderer.js
@@ -60,9 +60,9 @@ GeoExt.FeatureRenderer = Ext.extend(Ext.BoxComponent, {
 
     /** api: config[labelText]
      *  ``String``
-     *  Label text to display for text features. Defaults to Ab.
+     *  Label text to display for text features.
      */
-    labelText: 'Ab',
+    labelText: null,
     
     /** private: property[resolution]
      *  ``Number``
@@ -355,10 +355,8 @@ GeoExt.FeatureRenderer = Ext.extend(Ext.BoxComponent, {
                 // TODO: remove this when OpenLayers.Symbolizer is used everywhere
                 symbolizer = Ext.apply({}, symbolizer);
             }
-            if (symbolizer.clone && typeof symbolizer.clone === 'function' 
-                && symbolizer.label !== undefined) {
-                    symbolizer = symbolizer.clone();
-                    symbolizer.label = this.labelText;
+            if (symbolizer.label !== undefined && this.labelText !== null) {
+                symbolizer.label = this.labelText;
             }
             this.renderer.drawFeature(
                 feature.clone(),

--- a/lib/GeoExt/widgets/VectorLegend.js
+++ b/lib/GeoExt/widgets/VectorLegend.js
@@ -477,6 +477,7 @@ GeoExt.VectorLegend = Ext.extend(GeoExt.LayerLegend, {
         }
         return {
             xtype: "gx_renderer",
+            labelText: "Ab",
             symbolType: haveType ? type : this.symbolType,
             symbolizers: symbolizers,
             style: this.clickableSymbol ? {cursor: "pointer"} : undefined,


### PR DESCRIPTION
...y display a readable text, this defaults to Ab but is configurable

One test is currently failing in FeatureRenderer, but it also fails before this change.
