### PR TITLE
Fixing the ZoomSlider size for OpenLayers >2.11

### DIFF
--- a/lib/GeoExt/widgets/ZoomSlider.js
+++ b/lib/GeoExt/widgets/ZoomSlider.js
@@ -177,7 +177,7 @@ GeoExt.ZoomSlider = Ext.extend(Ext.slider.SingleSlider, {
     bind: function(map) {
         this.map = map;
         this.map.events.on({
-            zoomend: this.update,
+            zoomend: this.onZoomEnd,
             updatesize: this.initZoomValues,
             changebaselayer: this.initZoomValues,
             scope: this
@@ -185,12 +185,19 @@ GeoExt.ZoomSlider = Ext.extend(Ext.slider.SingleSlider, {
         this.initZoomValues();
     },
     
+    /** private: method[onZoomEnd]
+     *  Registered as a listener for zoomend.
+     */
+    onZoomEnd: function() {
+        this.update();
+    },
+    
     /** private: method[unbind]
      */
     unbind: function() {
         if(this.map && this.map.events) {
             this.map.events.un({
-                zoomend: this.update,
+                zoomend: this.onZoomEnd,
                 updatesize: this.initZoomValues,
                 changebaselayer: this.initZoomValues,
                 scope: this
@@ -214,8 +221,7 @@ GeoExt.ZoomSlider = Ext.extend(Ext.slider.SingleSlider, {
                     layer.numZoomLevels - 1 : layer.maxZoomLevel;
             }
             // reset the thumb value so it gets repositioned when we call update
-            this.thumbs[0].value = null;
-            this.update();
+            this.update(true);
         }
     },
     
@@ -259,11 +265,22 @@ GeoExt.ZoomSlider = Ext.extend(Ext.slider.SingleSlider, {
     },
     
     /** private: method[update]
+     *  :param force: ``Boolean`` Force an update of the thumb position even
+     *      if the value may not have changed (but min/max or length have).
+     *
      *  Registered as a listener for map zoomend.  Updates the value of the slider.
      */
-    update: function() {
+    update: function(force) {
         if(this.rendered && this.map) {
             this.updating = true;
+            if (force) {
+                /**
+                 * This triggers repositioning even if the value doesn't 
+                 * change.  We want this when the min/max values change but 
+                 * the zoom level doesn't.
+                 */
+                this.thumbs[0].value = null;
+            }
             this.setValue(this.map.getZoom());
             this.updating = false;
         }

--- a/tests/lib/GeoExt/widgets/ZoomSlider.html
+++ b/tests/lib/GeoExt/widgets/ZoomSlider.html
@@ -84,6 +84,46 @@
             slider1.destroy();
             slider2.destroy();
         }
+
+        function test_more_aggressive(t) {
+            t.plan(2);
+
+            var panel = new GeoExt.MapPanel({
+                title: "Map",
+                renderTo: "map",
+                height: 256,
+                width: 512,
+                map: {
+                    controls: [new OpenLayers.Control.Navigation()],
+                    maxResolution: 0.703125
+                },
+                layers: [new OpenLayers.Layer.WMS(
+                    "Global Imagery",
+                    "http://maps.opengeo.org/geowebcache/service/wms",
+                    {layers: "bluemarble"}
+                )],
+                extent: [-5, 35, 15, 55]
+            });
+
+            // create a separate slider bound to the map but displayed elsewhere
+            var slider = new GeoExt.ZoomSlider({
+                map: panel.map,
+                aggressive: true,                                                                                                                                                   
+                width: 200,
+                plugins: new GeoExt.ZoomSliderTip({
+                    template: "<div>Zoom Level: {zoom}</div>"
+                }),
+                renderTo: document.body
+            });
+
+            t.eq(panel.map.getZoom(), 3, "map zoom");
+            t.eq(slider.getValue(), 3, "slider value");
+            
+            slider.destroy();
+            panel.destroy();
+
+        }
+        
         
         function test_zoomslider_update(t) {
             t.plan(4);


### PR DESCRIPTION
OpenLayers 2.12 restricts the minimum zoom level for maps that have a base layer with wrapDateLine set to true, so the map does not show more than one world. This change makes it so the ZoomSlider size is adjusted according to the minimum zoom level restriction in OpenLayers.

This fix depends on https://github.com/openlayers/openlayers/pull/524.

With tests; tests pass in Safari 5. Thanks for any review.
