### PR TITLE
Ignore custom parameters with null params for WMS layers 

### DIFF
--- a/lib/GeoExt/data/PrintProvider.js
+++ b/lib/GeoExt/data/PrintProvider.js
@@ -648,7 +648,7 @@ GeoExt.data.PrintProvider = Ext.extend(Ext.util.Observable, {
                 var param;
                 for(var p in layer.params) {
                     param = p.toLowerCase();
-                    if(!layer.DEFAULT_PARAMS[param] &&
+                    if(layer.params[p] != null && !layer.DEFAULT_PARAMS[param] &&
                     "layers,styles,width,height,srs".indexOf(param) == -1) {
                         if(!enc.customParams) {
                             enc.customParams = {};

--- a/tests/lib/GeoExt/data/PrintProvider.html
+++ b/tests/lib/GeoExt/data/PrintProvider.html
@@ -162,7 +162,7 @@
                 new OpenLayers.Layer.Vector("vector", {minScale: 1000000, maxScale: 50000}),
                 new OpenLayers.Layer.Markers("markers"),
                 new OpenLayers.Layer.WMS("don't print me", "http://demo.opengeo.org/geoserver/wms",
-                    {layers: "tasmania", transparent: true}, {
+                    {layers: "tasmania", transparent: true, cql_filter: null}, {
                         displayInLayerSwitcher: false,
                         isBaseLayer: false
                     }),


### PR DESCRIPTION
Custom params shall only be encoded when their value is not a null value. This avoids issues with GeoServer where e.g. `CQL_FILTER=null` causes an error.
