### PR TITLE
Fixing options being applied twice on google layers

### DIFF
--- a/lib/GeoExt/widgets/ZoomSlider.js
+++ b/lib/GeoExt/widgets/ZoomSlider.js
@@ -213,13 +213,22 @@ GeoExt.ZoomSlider = Ext.extend(Ext.slider.SingleSlider, {
         if (layer) {
             if(this.initialConfig.minValue === undefined) {
                 //TODO remove check for getMinZoom when we require OpenLayers 2.12.
-                var minZoom = this.map.getMinZoom ? this.map.getMinZoom() : 0;
-                this.minValue = Math.max(minZoom, layer.minZoomLevel || 0);
+                if(layer.CLASS_NAME == "OpenLayers.Layer.Google"){
+                    var minZoom = this.map.getMinZoom ? this.map.getMinZoom() : 0;
+                    this.minValue = Math.max(minZoom, 0);
+                }else{
+                    var minZoom = this.map.getMinZoom ? this.map.getMinZoom() : 0;
+                    this.minValue = Math.max(minZoom, layer.minZoomLevel || 0);
+                }
             }
             if(this.initialConfig.maxValue === undefined) {
-                this.maxValue = layer.minZoomLevel == null ?
-                    layer.numZoomLevels - 1 : layer.maxZoomLevel;
-            }
+                if(layer.CLASS_NAME == "OpenLayers.Layer.Google"){
+                    this.maxValue = layer.minZoomLevel == null ?
+                        layer.numZoomLevels - 1 : layer.maxZoomLevel - layer.minZoomLevel;
+                }else{
+                    this.maxValue = layer.minZoomLevel == null ?
+                        layer.numZoomLevels - 1 : layer.maxZoomLevel;
+                }
             // reset the thumb value so it gets repositioned when we call update
             this.update(true);
         }


### PR DESCRIPTION
The google layers use maxZoomLevel and minZoomLevel to remap the resolutions array and ZoomSlider become confused.
It's like applying twice the filter to the layer. 

This patch bypass those layer options if it's a google one. 

It might be good to validate that with other GYMO systems.
