### PR TITLE
Adds "Google" layer to PrintProviders

### DIFF
--- a/lib/GeoExt/data/PrintProvider.js
+++ b/lib/GeoExt/data/PrintProvider.js
@@ -847,6 +847,19 @@ GeoExt.data.PrintProvider = Ext.extend(Ext.util.Observable, {
                 var output = this.encoders.layers.Vector.call(this, vector);
                 vector.destroy();
                 return output;
+            },
+            "Google": function(layer) {
+                var enc = this.encoders.layers.TileCache.call(this, layer);
+                return Ext.apply(enc, {
+                    type: 'tiledGoogle',
+                    opacity: 1,
+                    baseURL: 'http://maps.google.com/maps/api/staticmap',
+                    resolutions: [156543.03390625, 78271.516953125, 39135.7584765625, 19567.87923828125, 9783.939619140625, 4891.9698095703125, 2445.9849047851562, 1222.9924523925781, 611.4962261962891, 305.74811309814453, 152.87405654907226, 76.43702827453613, 38.218514137268066, 19.109257068634033, 9.554628534317017, 4.777314267158508, 2.388657133579254, 1.194328566789627, 0.5971642833948135, 0.29858214169740677, 0.14929107084870338, 0.07464553542435169],
+                    extension: 'png',
+                    format: 'png',
+                    sensor: false,
+                    maptype: layer.type
+                });
             }
         },
         "legends": {


### PR DESCRIPTION
Enables printing (PDF) maps with Google background layers (tested with custom OpenGeo Suite 3 app).
Relates to [gxp pr 207](https://github.com/opengeo/gxp/pull/207).
