### PR TITLE
if baseParams has a FORMAT key, and the url contains FORMAT already, pre...

### DIFF
--- a/lib/GeoExt/widgets/WMSLegend.js
+++ b/lib/GeoExt/widgets/WMSLegend.js
@@ -161,15 +161,17 @@ GeoExt.WMSLegend = Ext.extend(GeoExt.LayerLegend, {
                 TIME: null
             });
         }
-        var params = OpenLayers.Util.upperCaseObject(this.baseParams);
+        var params = Ext.apply({}, this.baseParams);
         if (layer.params._OLSALT) {
             // update legend after a forced layer redraw
             params._OLSALT = layer.params._OLSALT;
         }
-        if (url.toLowerCase().indexOf("format=") !== -1 && params.FORMAT) {
-            delete params.FORMAT;
+        var appendParams = Ext.urlEncode(params);
+        var formatRegEx = /([&\?]?)format=[^&]*&?/i;
+        if (formatRegEx.test(appendParams) && formatRegEx.test(url)) {
+            url = url.replace(formatRegEx, '$1');
         }
-        url = Ext.urlAppend(url, Ext.urlEncode(params));
+        url = OpenLayers.Util.urlAppend(url, appendParams);
         if (url.toLowerCase().indexOf("request=getlegendgraphic") != -1) {
             if (url.toLowerCase().indexOf("format=") == -1) {
                 url = Ext.urlAppend(url, "FORMAT=image%2Fgif");

--- a/tests/lib/GeoExt/widgets/WMSLegend.html
+++ b/tests/lib/GeoExt/widgets/WMSLegend.html
@@ -93,7 +93,7 @@
 
             url = l.items.get(1) && l.items.get(1).url;
             t.eq(!!url, true, "legend image loaded even when MapPanel is not rendered at legend instantiation.")
-            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&FORMAT=image%2Fpng&FOO=bar%20bar";
+            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&FORMAT=image%2Fpng&foo=bar%20bar";
             t.eq(url, expectedUrl, "GetLegendGraphic url is generated correctly");
             l.destroy()
 
@@ -128,13 +128,13 @@
             }]);
             l = new GeoExt.WMSLegend({
                 renderTo: 'legendwms',
-                baseParams: {FORMAT: 'image/png'},
+                baseParams: {format: 'image/png'},
                 layerRecord: mapPanel.layers.getAt(0)
             });
             l.render();
             url = l.items.get(1).url;
-            // url should not be getting a duplicate FORMAT parameter
-            t.eq(url, "foo?request=getlegendgraphic&format=image/jpeg&SCALE=" + mapPanel.map.getScale(), "legend url from styles field of layer record used correctly.");
+            // url should not be getting a duplicate FORMAT parameter, baseParams will override
+            t.eq(url, "foo?request=getlegendgraphic&format=image%2Fpng&SCALE=" + mapPanel.map.getScale(), "legend url from styles field of layer record used correctly.");
             l.destroy();
 
             mapPanel.layers.getAt(0).set("styles", [{


### PR DESCRIPTION
...vent that we have duplicate FORMAT parameters in the url, e.g. ArcGIS Server will not like this and will return an exception
