### PR TITLE
When we enter an empty string in nillable number,

### DIFF
--- a/lib/GeoExt/widgets/form.js
+++ b/lib/GeoExt/widgets/form.js
@@ -212,7 +212,7 @@ GeoExt.form.recordToField = function(record, options) {
         var minValue = restriction["minInclusive"] !== undefined ?
             parseFloat(restriction["minInclusive"]) : undefined;
         field = Ext.apply({
-            xtype: "numberfield",
+            xtype: nillable ? "numberornullfield" : "numberfield" ,
             fieldLabel: label,
             maxValue: maxValue,
             minValue: minValue
@@ -252,3 +252,12 @@ GeoExt.form.recordToField.REGEXES = {
         "^(date|dateTime)$", "i"
     )
 };
+
+GeoExt.form.NumberOrNullField = Ext.extend(Ext.form.NumberField, {
+    getValue: function() {
+        value = GeoExt.form.NumberOrNullField.superclass.
+                getValue.apply(this, arguments);
+        return value === "" ? null : value;
+    }
+});
+Ext.reg('numberornullfield', GeoExt.form.NumberOrNullField);

--- a/tests/lib/GeoExt/widgets/form.html
+++ b/tests/lib/GeoExt/widgets/form.html
@@ -210,7 +210,7 @@
     }
 
     function test_recordToField(t) {
-        t.plan(31);
+        t.plan(38);
 
         // set up
 
@@ -234,9 +234,19 @@
         // labelStyle
         field = GeoExt.form.recordToField(store.getAt(1));
         field = Ext.ComponentMgr.create(field);
-        t.eq(field.labelStyle, '', "[label] nillable field default labelStyle is correct");
+        t.eq(field.labelStyle, 'font-weight:bold;', "[label] non nillable field default labelStyle is correct");
 
         field = GeoExt.form.recordToField(store.getAt(1), {
+            mandatoryFieldLabelStyle: 'font-style:italic;'
+        });
+        field = Ext.ComponentMgr.create(field);
+        t.eq(field.labelStyle, 'font-style:italic;', "[label] non nillable field labelStyle is not overriden by the mandatoryFieldLabelStyle option");
+
+        field = GeoExt.form.recordToField(store.getAt(26));
+        field = Ext.ComponentMgr.create(field);
+        t.eq(field.labelStyle, '', "[label] nillable field default labelStyle is correct");
+
+        field = GeoExt.form.recordToField(store.getAt(26), {
             mandatoryFieldLabelStyle: 'font-style:italic;'
         });
         field = Ext.ComponentMgr.create(field);
@@ -303,6 +313,18 @@
         t.eq(field.name, "SAMP_POP", "[num] field name is correct");
         t.eq(field.maxValue, 10, "[num] field maxValue is correct");
         t.eq(field.minValue, 5, "[num] field minValue is correct");
+
+        t.ok(!(field instanceof GeoExt.form.NumberOrNullField), "[num] field is not a number or null field");
+        field.setValue('')
+        t.eq(field.getValue(), '', "[num] empty value is an empty string")
+
+        //num or null
+        field = GeoExt.form.recordToField(store.getAt(26));
+        field = Ext.ComponentMgr.create(field);
+        t.ok(field instanceof GeoExt.form.NumberOrNullField, "[numornull] field is not a number or null field");
+        t.eq(field.name, "SAMP_NIL", "[numornull] field name is correct");
+        field.setValue('')
+        t.eq(field.getValue(), null, "[numornull] empty value is null")
         
         // boolean
         field = GeoExt.form.recordToField(store.getAt(2), {checkboxLabelProperty: 'fieldLabel'});

--- a/tests/lib/GeoExt/widgets/form.js
+++ b/tests/lib/GeoExt/widgets/form.js
@@ -15,7 +15,7 @@ var doc = (new OpenLayers.Format.XML).read(
               '</xsd:restriction>' +
             '</xsd:simpleType>' +
           '</xsd:element>' +
-          '<xsd:element maxOccurs="1" minOccurs="0" name="SAMP_POP" nillable="true">' +
+          '<xsd:element maxOccurs="1" minOccurs="0" name="SAMP_POP" nillable="false">' +
             '<xsd:simpleType>' +
               '<xsd:restriction base="xsd:double">' +
                 '<xsd:maxInclusive value="10"/>' +
@@ -52,6 +52,14 @@ var doc = (new OpenLayers.Format.XML).read(
                 '<xsd:enumeration value="pop"/>' +
                 '<xsd:enumeration value="soda"/>' +
                 '<xsd:enumeration value="other"/>' +
+              '</xsd:restriction>' +
+            '</xsd:simpleType>' +
+          '</xsd:element>' +
+          '<xsd:element maxOccurs="1" minOccurs="0" name="SAMP_NIL" nillable="true">' +
+            '<xsd:simpleType>' +
+              '<xsd:restriction base="xsd:double">' +
+                '<xsd:maxInclusive value="10"/>' +
+                '<xsd:minInclusive value="5"/>' +
               '</xsd:restriction>' +
             '</xsd:simpleType>' +
           '</xsd:element>' +


### PR DESCRIPTION
Use the value null instance of "".

It's needed with mapfish protocol because if the database allow it we can set an int value to null but not to "".
