### PR TITLE
WMSCapabilitiesReader generates layer attribution object

### DIFF
--- a/lib/GeoExt/data/WMSCapabilitiesReader.js
+++ b/lib/GeoExt/data/WMSCapabilitiesReader.js
@@ -29,6 +29,9 @@ Ext.namespace("GeoExt.data");
  *          to the ``OpenLayers.Layer.WMS`` constructor.
  *          ``layerParams`` is an optional set of parameters to pass into the
  *          ``OpenLayers.Layer.WMS`` constructor.
+ *          ``rawAttribution`` a ``boolean``. If true, the reader does not
+ *          generate attribution markup, but a full attribution object.
+ *          Defaults to false.
  *      :param recordType: ``Array | Ext.data.Record`` An array of field
  *          configuration objects or a record object.  Default is
  *          :class:`GeoExt.data.LayerRecord` with the following fields:
@@ -199,7 +202,9 @@ Ext.extend(GeoExt.data.WMSCapabilitiesReader, Ext.data.DataReader, {
                     }
                     options = {
                         attribution: layer.attribution ?
-                            this.attributionMarkup(layer.attribution) :
+                            (this.meta.rawAttribution ?
+                                layer.attribution :
+                                this.attributionMarkup(layer.attribution)) :
                             undefined,
                         minScale: layer.minScale,
                         maxScale: layer.maxScale

--- a/tests/lib/GeoExt/data/WMSCapabilitiesReader.html
+++ b/tests/lib/GeoExt/data/WMSCapabilitiesReader.html
@@ -168,6 +168,26 @@
             t.eq(transparent, true,
                 "TRANSPARENT param is true if no opacity set");
         }
+
+        function test_attribution(t) {
+            t.plan(1);
+
+            var reader = new GeoExt.data.WMSCapabilitiesReader({rawAttribution: true}, []);
+            var records = reader.read({responseXML: doc});
+
+            // 1 test -- attribution markup
+            var record = records.records[2];
+            t.eq(record.getLayer().attribution, {
+                title: "Foo Authority",
+                href: "http://foo/about/",
+                logo: {
+                    format: "image/png",
+                    width: "24",
+                    height: "24",
+                    href: "http://foo/logo.png"
+                }
+            }, "attribution object is correct when rawAttribution is set to true");
+        }
     </script>
   <body>
     <div id="map"></div>


### PR DESCRIPTION
The `rawAttribution` configuration option is added to the WMSCapabilitiesReader, which allows the reader to generate fully fledged attribution objects rather than HTML markup.

By default, the behavior is unchanged: HTML markup is generated.

This PR depends on https://github.com/openlayers/openlayers/pull/1182

Tests pass, TIA for any review.
