### PR TITLE
WMS print encoder supports WMS 1.3.0

### DIFF
--- a/lib/GeoExt/data/PrintProvider.js
+++ b/lib/GeoExt/data/PrintProvider.js
@@ -648,7 +648,7 @@ GeoExt.data.PrintProvider = Ext.extend(Ext.util.Observable, {
                 for(var p in layer.params) {
                     param = p.toLowerCase();
                     if(layer.params[p] != null && !layer.DEFAULT_PARAMS[param] &&
-                    "layers,styles,width,height,srs".indexOf(param) == -1) {
+                    "layers,styles,width,height,srs,crs".indexOf(param) == -1) {
                         if(!enc.customParams) {
                             enc.customParams = {};
                         }

--- a/lib/GeoExt/data/PrintProvider.js
+++ b/lib/GeoExt/data/PrintProvider.js
@@ -639,6 +639,7 @@ GeoExt.data.PrintProvider = Ext.extend(Ext.util.Observable, {
                 var enc = this.encoders.layers.HTTPRequest.call(this, layer);
                 Ext.apply(enc, {
                     type: 'WMS',
+                    version: layer.params.VERSION,
                     layers: [layer.params.LAYERS].join(",").split(","),
                     format: layer.params.FORMAT,
                     styles: [layer.params.STYLES].join(",").split(","),

--- a/lib/GeoExt/data/PrintProvider.js
+++ b/lib/GeoExt/data/PrintProvider.js
@@ -637,7 +637,6 @@ GeoExt.data.PrintProvider = Ext.extend(Ext.util.Observable, {
             },
             "WMS": function(layer) {
                 var enc = this.encoders.layers.HTTPRequest.call(this, layer);
-                enc.singleTile = layer.singleTile;
                 Ext.apply(enc, {
                     type: 'WMS',
                     layers: [layer.params.LAYERS].join(",").split(","),

--- a/tests/lib/GeoExt/data/PrintProvider.html
+++ b/tests/lib/GeoExt/data/PrintProvider.html
@@ -310,6 +310,7 @@
                     "singleTile":false,
                     "type":"WMS",
                     "layers":["topp:tasmania_state_boundaries","topp:tasmania_water_bodies"],
+                    "version": "1.1.1",
                     "format":"image/gif",
                     "styles":[""],
                     "customParams":{"VENDORFOO":"bar", "map_resolution": 150}
@@ -430,7 +431,7 @@
                     zoomOffset:14, 
                     resolutions:[4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250, 2000, 1750, 1500, 1250, 1000, 750, 650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5]
                 }],
-                "pages":[{"mapTitle":"foo","comment":"bar","center":[1,2],"scale":4000000,"rotation":0}],"customParam":"foo","legends":[{"name":"tilecache","classes":[{"name":"","icon":"http://trac.geoext.org/chrome/site/img/GeoExt.png"}]},{"name": "wms", "classes":[{"name":"","icons":["http://demo.opengeo.org/geoserver/wms?VENDORFOO=bar&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=topp%3Atasmania_water_bodies&FORMAT=image%2Fgif&SCALE=4000000", "http://demo.opengeo.org/geoserver/wms?VENDORFOO=bar&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=topp%3Atasmania_state_boundaries&FORMAT=image%2Fgif&SCALE=4000000"]}]}],"overviewLayers":[{"baseURL":"http://foo/","format":"image/jpeg",layers:["mylayer"],"opacity":1,"singleTile":false,styles:[""],type:"WMS", "customParams": {"map_resolution": 150}}]};
+                "pages":[{"mapTitle":"foo","comment":"bar","center":[1,2],"scale":4000000,"rotation":0}],"customParam":"foo","legends":[{"name":"tilecache","classes":[{"name":"","icon":"http://trac.geoext.org/chrome/site/img/GeoExt.png"}]},{"name": "wms", "classes":[{"name":"","icons":["http://demo.opengeo.org/geoserver/wms?VENDORFOO=bar&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=topp%3Atasmania_water_bodies&FORMAT=image%2Fgif&SCALE=4000000", "http://demo.opengeo.org/geoserver/wms?VENDORFOO=bar&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=topp%3Atasmania_state_boundaries&FORMAT=image%2Fgif&SCALE=4000000"]}]}],"overviewLayers":[{"baseURL":"http://foo/","format":"image/jpeg",layers:["mylayer"],"opacity":1,"singleTile":false,styles:[""],type:"WMS", version: "1.1.1", "customParams": {"map_resolution": 150}}]};
 
             t.eq(log.request.jsonData, expect, "Request with encoded layers and legend is correct.");
 
@@ -495,6 +496,7 @@
                     "singleTile": false,
                     "type": "WMS",
                     "layers": ["topp:tasmania_state_boundaries"],
+                    "version": "1.1.1",
                     "format": "image/gif",
                     "styles": [""]
                 },{
@@ -503,6 +505,7 @@
                     "singleTile": false,
                     "type": "WMS",
                     "layers": ["topp:tasmania_water_bodies"],
+                    "version": "1.1.1",
                     "format": "image/gif",
                     "styles": [""]
                 }],


### PR DESCRIPTION
After https://github.com/mapfish/mapfish-print/pull/102, the WMS print encoder requires an update so that it takes into account the WMS `VERSION` parameter and does not send the 1.3.0-specific `CRS` parameter into the layer customParams.

Tests pass, please review.
