### PR TITLE
Make sure coordinates and zoom are available in state before applying them

### DIFF
--- a/lib/GeoExt/widgets/MapPanel.js
+++ b/lib/GeoExt/widgets/MapPanel.js
@@ -256,8 +256,12 @@ GeoExt.MapPanel = Ext.extend(Ext.Panel, {
         // if we get strings for state.x, state.y or state.zoom
         // OpenLayers will take care of converting them to the
         // appropriate types so we don't bother with that
-        this.center = new OpenLayers.LonLat(state.x, state.y);
-        this.zoom = state.zoom;
+        if('x' in state && 'y' in state) {
+            this.center = new OpenLayers.LonLat(state.x, state.y);
+        }
+        if('zoom' in state) {
+            this.zoom = state.zoom;
+        }
 
         // set layer visibility and opacity
         var i, l, layer, layerId, visibility, opacity;


### PR DESCRIPTION
As for now MapPanel's applyState function assumes that the coordinates and zoomlevel are available in the state object. This can be a problem if for any reason those data are not provided.
See for instance: http://api.geoext.org/1.1/examples/permalink.html?map_foo=bar
