### PR TITLE
Add support for custom combos in PrintProviderField

### DIFF
--- a/lib/GeoExt/plugins/PrintProviderField.js
+++ b/lib/GeoExt/plugins/PrintProviderField.js
@@ -178,6 +178,13 @@ GeoExt.plugins.PrintProviderField = Ext.extend(Ext.util.Observable, {
                     break;
                 case printProvider.outputFormats:
                     printProvider.setOutputFormat(record);
+                    break;
+                default:
+                    // Case of a custom combobox
+                    var fieldname = field.name || field.valueField;
+                    if (fieldname) {
+                        printProvider.customParams[fieldname] = value;
+                    }
             }
         } else {
             printProvider.customParams[field.name] = value;


### PR DESCRIPTION
Hello

as for now, in plugin PrintProviderField, only the standard layout/dpi/format combos are taken into account. Any other custom combo is ignored:
https://github.com/geoext/geoext/blob/master/lib/GeoExt/plugins/PrintProviderField.js#L172-L180
whereas it is possible to add any other field (textfield for instance) thanks to:
https://github.com/geoext/geoext/blob/master/lib/GeoExt/plugins/PrintProviderField.js#L183

This PR adds the support of custom combos.
