### PR TITLE
WMSCapabilitiesReader->attributionMarkup does not take into account width and height of logo image

### DIFF
--- a/lib/GeoExt/data/WMSCapabilitiesReader.js
+++ b/lib/GeoExt/data/WMSCapabilitiesReader.js
@@ -252,6 +252,8 @@ Ext.extend(GeoExt.data.WMSCapabilitiesReader, Ext.data.DataReader, {
         
         if (attribution.logo){
             markup.push("<img class='"+this.attributionCls+"-image' "
+                        + "width='" + attribution.logo.width + "' "
+                        + "height='" + attribution.logo.height + "' "
                         + "src='" + attribution.logo.href + "' />");
         }
         

--- a/tests/lib/GeoExt/data/WMSCapabilitiesReader.html
+++ b/tests/lib/GeoExt/data/WMSCapabilitiesReader.html
@@ -43,7 +43,7 @@
         }
 
         function test_read(t) {
-            t.plan(41);
+            t.plan(39);
 
             // test a reader with the only two default LayerRecord fields
             var reader = new GeoExt.data.WMSCapabilitiesReader({}, []);
@@ -147,13 +147,12 @@
             t.eq(layer.singleTile, true, "[2] layer field has correct singleTile attribute (from WMSCapabilitiesReader constructor)");
             t.eq(layer.params.FOO, "TRUE", "[2] layer field has correct custom parameter");
             
-            // 3 tests -- attribution markup
+            // 1 test -- attribution markup
             record = records.records[2];
             layer = record.getLayer();
             var attribution = layer.attribution;
-            t.ok(attribution.indexOf("http://foo/logo.png") !== -1, "attribution markup has a logo");
-            t.ok(attribution.indexOf("Foo Authority") !== -1, "attribution markup has a title");
-            t.ok(attribution.indexOf("http://foo/about/") !== -1, "attribution has a link");
+            var expect = "<a class='gx-attribution-link' href=http://foo/about/><img class='gx-attribution-image' width='24' height='24' src='http://foo/logo.png' /></a> <a class='gx-attribution-link' href=http://foo/about/><span class='gx-attribution-title'>Foo Authority</span></a>";
+            t.eq(attribution, expect, "Attribution HTML is correct");
             
             // 2 tests - transparent param
             var transparent;


### PR DESCRIPTION
OpenLayers does parse this info, but it isn't used, so logo images are displayed at their original size.

Both width and height are required attributes.
