### PR TITLE
New calculateEnclosingPageBounds method extending calculatePageBounds

### DIFF
--- a/lib/GeoExt/data/PrintPage.js
+++ b/lib/GeoExt/data/PrintPage.js
@@ -319,7 +319,32 @@ GeoExt.data.PrintPage = Ext.extend(Ext.util.Observable, {
         return new OpenLayers.Bounds(center.lon - w, center.lat - h,
             center.lon + w, center.lat + h);
     },
-    
+
+    /** private: method[calculateEnclosingPageBounds]
+     *  :param scale: ``Ext.data.Record`` Scale record to calculate the page
+     *      bounds for.
+     *  :param units: ``String`` Map units to use for the scale calculation.
+     *      Optional if ``feature`` is added to a layer which is added to a
+     *      map. If not provided, "dd" will be assumed.
+     *  :return: ``OpenLayers.Bounds``
+     *
+     *  Calculates the enclosing bounds of the page taking into account the
+     *  rotation value.
+     */
+    calculateEnclosingPageBounds: function(scale, units) {
+        var bounds = this.calculatePageBounds(scale, units);
+        var rotation = this.rotation;
+        if(rotation != 0) {
+            var geom = bounds.toGeometry();
+            var center = bounds.getCenterLonLat();
+            geom.rotate(this.rotation,
+                        new OpenLayers.Geometry.Point(center.lon, center.lat));
+            geom.calculateBounds();
+            bounds = geom.getBounds();
+        }
+        return bounds;
+    },
+
     /** private: method[onLayoutChange]
      *  Handler for the printProvider's layoutchange event.
      */

--- a/lib/GeoExt/data/PrintProviderBase.js
+++ b/lib/GeoExt/data/PrintProviderBase.js
@@ -547,7 +547,7 @@ GeoExt.data.PrintProviderBase = Ext.extend(Ext.util.Observable, {
 
         var bounds = new OpenLayers.Bounds();
         Ext.each(pages, function(page) {
-            bounds.extend(page.calculatePageBounds(page.scale, map.getUnits()));
+            bounds.extend(page.calculateEnclosingPageBounds(page.scale, map.getUnits()));
         });
 
         var pagesLayer = pages[0].feature.layer;


### PR DESCRIPTION
Take into account the page rotation. 
Solve the problem of vector features left out because the reference page bounds are not rotated.
See https://github.com/geoext/geoext/issues/123
